### PR TITLE
Allow to use big integer constants

### DIFF
--- a/ext/pk11.c
+++ b/ext/pk11.c
@@ -1376,6 +1376,7 @@ ck_attr_initialize(int argc, VALUE *argv, VALUE self)
     attr->ulValueLen = 0;
     break;
   case T_FIXNUM:
+  case T_BIGNUM:
     attr->pValue = (CK_BYTE_PTR)malloc(sizeof(CK_OBJECT_CLASS));
     *((CK_OBJECT_CLASS*)attr->pValue) = NUM2ULONG(value);
     attr->ulValueLen = sizeof(CK_OBJECT_CLASS);
@@ -1531,6 +1532,7 @@ cCK_MECHANISM_set_pParameter(VALUE self, VALUE value)
     m->ulParameterLen = RSTRING_LEN(value);
     break;
   case T_FIXNUM:
+  case T_BIGNUM:
     ulong_val = NUM2ULONG(value);
     value = rb_obj_freeze(rb_str_new((char*)&ulong_val, sizeof(ulong_val)));
     m->pParameter = RSTRING_PTR(value);

--- a/lib/pkcs11/helper.rb
+++ b/lib/pkcs11/helper.rb
@@ -134,6 +134,8 @@ module PKCS11
           PKCS11::CK_MECHANISM.new(mech, param)
         when Fixnum
           PKCS11::CK_MECHANISM.new(mechanism)
+        when Bignum
+          PKCS11::CK_MECHANISM.new(mechanism)
         else
           mechanism
       end


### PR DESCRIPTION
When you need to access some legacy libraries, you should use "private" constants.
All of them are defined as numbers higher than 0x80000000.
In 64bit mode its working fine, since it still Fixnum.
But in 32bit mode its are Bigint numbers, that are still can be written into UINT.
